### PR TITLE
groups for elements and middlewares (panel name)

### DIFF
--- a/src/elementManager/ElementManager.java
+++ b/src/elementManager/ElementManager.java
@@ -81,7 +81,7 @@ public class ElementManager {
     }
 
     public void removeElementsByGroup(String group) {
-        ArrayList<Element> elementsArr = getElementsByGroup("group");
+        ArrayList<Element> elementsArr = getElementsByGroup(group);
         if (elementsArr == null) return;
 
         for (Element element : elementsArr) {

--- a/src/middlewareManager/middlewares/DrawBigBall.java
+++ b/src/middlewareManager/middlewares/DrawBigBall.java
@@ -53,6 +53,7 @@ public class DrawBigBall extends Middleware {
     @Override
     public void init(){
         Config.getElementManager().addElement("bigBall", bigBall);
+        Config.getElementManager().joinGroup(panelId, bigBall.getId());
         if(rgb != null){
             bigBall.setColor(new Color(Integer.decode(rgb)));
         }

--- a/src/middlewareManager/middlewares/DrawLine.java
+++ b/src/middlewareManager/middlewares/DrawLine.java
@@ -45,6 +45,7 @@ public class DrawLine extends Middleware {
                 elementManager.addElement("line"+(SBall).getNumber(), line);
                 //adding line to Group "lines"
                 elementManager.joinGroup("lines", "line"+(SBall).getNumber());
+                elementManager.joinGroup("game", "line"+(SBall).getNumber());
             }
         }
     }

--- a/src/middlewareManager/middlewares/DrawSmallBall.java
+++ b/src/middlewareManager/middlewares/DrawSmallBall.java
@@ -9,7 +9,7 @@ import utils.calculations.Angle;
 import java.awt.Color;
 
 //This middleware create a SmallBall instance.
-//Then it will add it to "rotatingSmallBalls" Group.
+//Then it will add it to "rotatingSmallBalls" Group or "selectShooting"
 //The constructor accepts String so it can work around "LoadGame" shortcomings.
 //The us of "n" variable is to ensure that we won't use duplicate id.
 
@@ -93,6 +93,7 @@ public class DrawSmallBall extends Middleware{
             elementManager.addElement("smallBall"+id, smallBall);
             //adding SmallBall to "rotatingSmallBalls" Group.
             elementManager.joinGroup("rotatingSmallBalls", "smallBall"+id);
+            elementManager.joinGroup("game", "smallBall"+id);
             this.remove();
             return;
         }
@@ -108,6 +109,7 @@ public class DrawSmallBall extends Middleware{
         elementManager.addElement("smallBall"+id, smallBall);
         //adding SmallBall to "selectShootBall" Group.
         elementManager.joinGroup("selectShootBall", "smallBall"+id);
+        elementManager.joinGroup("game", "smallBall"+id);
         this.remove();
     }
     

--- a/src/middlewareManager/middlewares/GameOver.java
+++ b/src/middlewareManager/middlewares/GameOver.java
@@ -38,8 +38,9 @@ public class GameOver extends Middleware {
         }
         //pausing middlewares,showing gameover panel and removing self.
         else{
-            this.middlewareManager.setPausedMiddlewaresByGroup(panelId, true);
             this.middlewareManager.addMiddleware(new TransitionPanels("game", "gameOver"), new MiddlewareLocation());
+            this.middlewareManager.removeMiddlewaresByGroup(panelId);
+            Config.getElementManager().removeElementsByGroup(panelId);
             //TODO remove elements
             this.remove();
         }

--- a/src/middlewareManager/middlewares/LevelTimer.java
+++ b/src/middlewareManager/middlewares/LevelTimer.java
@@ -6,11 +6,10 @@ import config.Config;
 import frameManager.panels.GamePanel;
 
 public class LevelTimer extends Middleware {
-      JLabel updateTimeLabel;
-  long startTime=System.currentTimeMillis();
-    public LevelTimer(String id) {
+    JLabel updateTimeLabel;
+    long startTime=System.currentTimeMillis();
+    public LevelTimer() {
         super("levelTimer");
-        
     }
     public void init(){
        this.setValue("levelStartTime",String.valueOf(startTime));

--- a/src/middlewareManager/middlewares/LoadGame.java
+++ b/src/middlewareManager/middlewares/LoadGame.java
@@ -96,20 +96,37 @@ public class LoadGame extends Middleware {
             middlewareManager.addMiddlewareInSeries(new DrawSmallBall("90",this.getValue("smallBallsColor"),panelId,false));
         }
         //moving first ball into position
-        middlewareManager.addMiddlewareInSeries(new ReloadShootingBall());
+        Middleware reloadShootingBall = new ReloadShootingBall();
+        middlewareManager.addMiddlewareInSeries(reloadShootingBall);
+        middlewareManager.joinGroup(panelId, reloadShootingBall);
         //rotating small balls that are in orbit
-        middlewareManager.addMiddlewareInSeries(new SpinSmallBalls());
+        Middleware spinSmallBalls = new SpinSmallBalls();
+        middlewareManager.addMiddlewareInSeries(spinSmallBalls);
+        middlewareManager.joinGroup(panelId, spinSmallBalls);
         //drawing lines
-        middlewareManager.addMiddlewareInSeries(new DrawLine(panelId));
+        Middleware drawLines = new DrawLine(panelId);
+        middlewareManager.addMiddlewareInSeries(drawLines);
+        middlewareManager.joinGroup(panelId, drawLines);
         //checking impact
-        middlewareManager.addMiddlewareInSeries(new CheckImpact());
+        Middleware checkImpact = new CheckImpact();
+        middlewareManager.addMiddlewareInSeries( checkImpact);
+        middlewareManager.joinGroup(panelId, checkImpact);
         //moving shooting balls upward
-        middlewareManager.addMiddlewareInSeries(new MoveSmallBall());
+        Middleware moveSmallBalls = new MoveSmallBall();
+        middlewareManager.addMiddlewareInSeries(moveSmallBalls);
+        middlewareManager.joinGroup(panelId, moveSmallBalls);
         //checking for remaining balls if there is none, the level is finished
-        middlewareManager.addMiddlewareInSeries(new CheckRemainigBalls(panelId));
+        Middleware checkRemainingBalls = new CheckRemainigBalls(panelId);
+        middlewareManager.addMiddlewareInSeries(checkRemainingBalls);
+        middlewareManager.joinGroup(panelId, checkRemainingBalls);
+        //adding level timer
+        Middleware levelTimer = new LevelTimer();
+        middlewareManager.addMiddlewareInSeries(levelTimer);
+        middlewareManager.joinGroup(panelId,levelTimer);
         //adding rendering middleware
-        middlewareManager.addMiddlewareInSeries(new RepaintPanelElements(Config.getFrameManager().getAPanel(panelId)));
-        
+        Middleware repaintPanelElements = new RepaintPanelElements(Config.getFrameManager().getAPanel(panelId));
+        middlewareManager.addMiddlewareInSeries(repaintPanelElements);
+        middlewareManager.joinGroup(panelId,repaintPanelElements);
         this.remove();
         
     }


### PR DESCRIPTION
changes:
1. fixed a minor bug in ElementManger.
2. LoadGame now adds middlewares to a group. (group name is the name of the panel that the game is running on. "game" by default)
3. "Draw" middlewares now add their elements to a group with the name of the panel that they will be draw on.
4. GameOver now remove elements from the panel.
5. GameOver now remove middlewares.